### PR TITLE
fix: some url doesn't use .jsp anymore

### DIFF
--- a/extractor/kr/sbs.py
+++ b/extractor/kr/sbs.py
@@ -344,13 +344,14 @@ def get_data(hd):
         if 'spv.sbs.co.kr' in data['CONTENT']:
             h = data['CONTENT']
             for i in re.findall(r'https?://[^\s"<>]+', h):
-                img_list.add((i, re.search(r"image_id=([^&]+)", i).group(1)))
+                if 'image_id' in i:
+                    img_list.add((i, re.search(r"[?&]image_id=([^&]+)", i).group(1)))
 
         site_req.session.close()
         print(f"Title: {post_title}")
         print(f"Date: {post_date}")
         print(f"Found {len(img_list)} image(s)")
-
+        
         dir = [SITE_INFO.name, category, f"{post_date_short} {post_title}"]
 
         payload = DataPayload(


### PR DESCRIPTION
This pull request includes a small but important change to the `get_visual_board` function in `extractor/kr/sbs.py`. The change ensures that only URLs containing the `image_id` parameter are processed, improving the robustness of the code.

* [`extractor/kr/sbs.py`](diffhunk://#diff-d137ebad74749c220dddc4b6c0a6102676222ac8f8d7d77882a26316f2c51494L347-R348): Updated the `get_visual_board` function to add a conditional check for the presence of `image_id` in URLs before extracting and adding them to `img_list` to prevent potential errors.